### PR TITLE
FIX: check of billing company was wrong

### DIFF
--- a/includes/class-dolibarr.php
+++ b/includes/class-dolibarr.php
@@ -107,7 +107,8 @@ class Doliwoo_Dolibarr {
 		if ( 0 !== $thirdparty_id ) {
 			$order->thirdparty_id = $thirdparty_id;
 		} else {
-			if ( 0 === intval( get_user_meta( $user_id, 'billing_company', true ) ) ) {
+			$billing_company = get_user_meta( $user_id, 'billing_company', true );
+			if ( empty ( $billing_company ) ) {
 				if ( wp_verify_nonce( 'woocommerce-cart' ) ) {
 					$billing_company = $_POST['billing_company'];
 				} else {

--- a/includes/class-dolibarr.php
+++ b/includes/class-dolibarr.php
@@ -98,16 +98,10 @@ class Doliwoo_Dolibarr {
 
 		// Fill this array with all data required to create an order in Dolibarr
 		$user_id = get_current_user_id();
-		if ( 0 === $user_id ) {
-			// default to the generic user
-			$thirdparty_id = $this->settings->dolibarr_generic_id;
-		} else {
-			$thirdparty_id = intval( get_user_meta( $user_id, 'dolibarr_id', true ) );
-		}
 		
 		// Check thirdparty exists
-		if ( 0 !== $thirdparty_id  && $this->dolibarr_thirdparty_exists( $thirdparty_id ) ) {
-			$order->thirdparty_id = $thirdparty_id;
+		if ( $this->dolibarr_thirdparty_exists( $user_id ) ) {
+			$order->thirdparty_id = intval( get_user_meta( $user_id, 'dolibarr_id', true ) );
 		} else {
 			$billing_company = get_user_meta( $user_id, 'billing_company', true );
 			if ( empty ( $billing_company ) ) {

--- a/includes/class-dolibarr.php
+++ b/includes/class-dolibarr.php
@@ -104,7 +104,9 @@ class Doliwoo_Dolibarr {
 		} else {
 			$thirdparty_id = intval( get_user_meta( $user_id, 'dolibarr_id', true ) );
 		}
-		if ( 0 !== $thirdparty_id ) {
+		
+		// Check thirdparty exists
+		if ( 0 !== $thirdparty_id  && $this->dolibarr_thirdparty_exists( $thirdparty_id ) ) {
 			$order->thirdparty_id = $thirdparty_id;
 		} else {
 			$billing_company = get_user_meta( $user_id, 'billing_company', true );


### PR DESCRIPTION
that was causing order creation to abruptly stop
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/altatof%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/396322%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/GPCsolutions/doliwoo/pull/83%23issuecomment-214214053%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-04-25T08%3A53%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/396322%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/altatof%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20your%20contribution%20but%20could%20you%20please%20open%20a%20bug%20report%20instead%3F%5Cr%5Cn%5Cr%5CnI%20suspect%20something%20going%20wrong%20elsewhere.%5Cr%5Cn%5Cr%5CnYou%27re%20not%20supposed%20to%20have%20to%20make%20another%20time-consuming%20request%20to%20Dolibarr%20%28%60%60%60dolibarr_thirdparty_exists%28%29%60%60%60%29%20to%20get%20this%20information.%20It%20should%20be%20already%20cached%20into%20WooCommerce%20%28%60%60%60dolibarr_id%60%60%60%20meta%29%20at%20user%20creation.%22%2C%20%22created_at%22%3A%20%222016-04-25T15%3A57%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1210367%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rdoursenaud%22%7D%7D%2C%20%7B%22body%22%3A%20%22you%20are%20right%20BUT%20if%20the%20thirdpart%20id%20stored%20in%20doliwoo%20does%20not%20exist%20anymore%20in%20dolibarr%2C%20there%20is%20a%20big%20problem%20at%20the%20moment%22%2C%20%22created_at%22%3A%20%222016-04-25T16%3A17%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/396322%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/altatof%22%7D%7D%2C%20%7B%22body%22%3A%20%22anyway%2C%20there%20is%20another%20problem%20with%20this%20transmission%20of%20the%20order%20to%20dolibarr%20as%20you%20pointed%20out%20it%20is%20very%20time%20consuming%20and%20the%20user%20wait%20without%20knowing%20what%27s%20happening...%5Cr%5Cnone%20solution%20would%20be%20to%20put%20a%20jquery%20loading%20image%20during%20the%20webservice%20call%3B%20otherwise%20i%20wonder%20if%20the%20conversation%20between%20woocommerce%20and%20dolibarr%20should%20not%20better%20be%20asynchronous%20via%20a%20batch%20croned%20task%20%28as%20i%20suppose%20you%20already%20do%20for%20product%20sync%29%20%3F%22%2C%20%22created_at%22%3A%20%222016-04-25T16%3A21%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/396322%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/altatof%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%27re%20right.%20This%20edge%20case%20should%20be%20handled%20nicely.%5Cr%5CnAgain%2C%20please%20open%20an%20issue%20%3B%29%5Cr%5Cn%5Cr%5CnOn%20the%20other%20hand%2C%20everything%20is%20done%20synchronously%20at%20the%20moment%20for%20ease%20of%20debugging%20and%20because%20PHP%20is%20utterly%20bad%20at%20that%5Cu2026%20I%20have%20some%20ideas%20in%20mind%20to%20allow%20for%20a%20more%20flexible%20architecture%20but%20I%20miss%20founding%20for%20this%20project%20and%20overall%20time%20to%20seek%20founding%20%3A%28%5Cr%5Cn%5Cr%5CnIn%20the%20meantime%2C%20any%20feedback%20to%20the%20user%20would%20be%20better%20than%20the%20current%20implementation%20but%20I%20haven%27t%20found%20a%20way%20to%20inject%20it%20nicely%20into%20WooCommerce%27s%20workflow.%5Cr%5Cn%5Cr%5CnFeel%20free%20to%20play%20with%20it%20anyway.%20It%27s%20great%20to%20see%20some%20developer%20interrest%21%22%2C%20%22created_at%22%3A%20%222016-04-25T16%3A38%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1210367%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rdoursenaud%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%20i%20will%20open%20an%20issue%20for%20the%20edge%20case.%5Cr%5CnI%20will%20also%20make%20an%20issue%20for%20the%20asynchronous%20stuff%20and%20i%27ll%20try%20to%20propose%20you%20some%20solutions%20i%20have%20in%20mind...%20%5Cr%5CnMy%20purpose%20is%20to%20use%20woocommerce%20on%20altairis.fr%20and%20i%20want%20to%20use%20doliwoo%20to%20communicate%20with%20our%20Dolibarr%2C%20so%20it%20will%20be%20part%20of%20my%20job%20to%20participate%20in%20doliwoo%27s%20improvement.%22%2C%20%22created_at%22%3A%20%222016-04-25T17%3A11%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/396322%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/altatof%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/GPCsolutions/doliwoo/pull/83%23issuecomment-214214053%22%2C%20%22https%3A//github.com/GPCsolutions/doliwoo/pull/83%23issuecomment-214415813%22%2C%20%22https%3A//github.com/GPCsolutions/doliwoo/pull/83%23issuecomment-214425679%22%2C%20%22https%3A//github.com/GPCsolutions/doliwoo/pull/83%23issuecomment-214427823%22%2C%20%22https%3A//github.com/GPCsolutions/doliwoo/pull/83%23issuecomment-214432818%22%2C%20%22https%3A//github.com/GPCsolutions/doliwoo/pull/83%23issuecomment-214445780%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/altatof'><img src='https://avatars.githubusercontent.com/u/396322?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/GPCsolutions/doliwoo/pull/83#issuecomment-214214053'>General Comment</a></b>
- <a href='https://github.com/altatof'><img border=0 src='https://avatars.githubusercontent.com/u/396322?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/rdoursenaud'><img border=0 src='https://avatars.githubusercontent.com/u/1210367?v=3' height=16 width=16'></a> Thanks for your contribution but could you please open a bug report instead?
  I suspect something going wrong elsewhere.
  You're not supposed to have to make another time-consuming request to Dolibarr (`dolibarr_thirdparty_exists()`) to get this information. It should be already cached into WooCommerce (`dolibarr_id` meta) at user creation.
- <a href='https://github.com/altatof'><img border=0 src='https://avatars.githubusercontent.com/u/396322?v=3' height=16 width=16'></a> you are right BUT if the thirdpart id stored in doliwoo does not exist anymore in dolibarr, there is a big problem at the moment
- <a href='https://github.com/altatof'><img border=0 src='https://avatars.githubusercontent.com/u/396322?v=3' height=16 width=16'></a> anyway, there is another problem with this transmission of the order to dolibarr as you pointed out it is very time consuming and the user wait without knowing what's happening...
  one solution would be to put a jquery loading image during the webservice call; otherwise i wonder if the conversation between woocommerce and dolibarr should not better be asynchronous via a batch croned task (as i suppose you already do for product sync) ?
- <a href='https://github.com/rdoursenaud'><img border=0 src='https://avatars.githubusercontent.com/u/1210367?v=3' height=16 width=16'></a> You're right. This edge case should be handled nicely.
  Again, please open an issue ;)
  On the other hand, everything is done synchronously at the moment for ease of debugging and because PHP is utterly bad at that… I have some ideas in mind to allow for a more flexible architecture but I miss founding for this project and overall time to seek founding :(
  In the meantime, any feedback to the user would be better than the current implementation but I haven't found a way to inject it nicely into WooCommerce's workflow.
  Feel free to play with it anyway. It's great to see some developer interrest!
- <a href='https://github.com/altatof'><img border=0 src='https://avatars.githubusercontent.com/u/396322?v=3' height=16 width=16'></a> ok i will open an issue for the edge case.
  I will also make an issue for the asynchronous stuff and i'll try to propose you some solutions i have in mind...
  My purpose is to use woocommerce on altairis.fr and i want to use doliwoo to communicate with our Dolibarr, so it will be part of my job to participate in doliwoo's improvement.

<a href='https://www.codereviewhub.com/GPCsolutions/doliwoo/pull/83?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/GPCsolutions/doliwoo/pull/83?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/GPCsolutions/doliwoo/pull/83?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/GPCsolutions/doliwoo/pull/83'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
